### PR TITLE
Remove time-cond from curl 

### DIFF
--- a/.github/workflows/update-cert.yaml
+++ b/.github/workflows/update-cert.yaml
@@ -32,7 +32,7 @@ jobs:
     - name: Update Mozilla cert.pem Nightly
       if: startsWith(matrix.os, 'ubuntu')
       run: |
-        curl --remote-name --time-cond cacert.pem https://curl.se/ca/cacert.pem
+        curl --remote-name https://curl.se/ca/cacert.pem
         git status
         DATE="$(date)"
         export DATE


### PR DESCRIPTION
doesn't work in GHA because the timestamp is always when the action is being run. Resolves #1